### PR TITLE
Feat: Add ParEGO UI selector and backend ParEGO logic for MOBO

### DIFF
--- a/main.py
+++ b/main.py
@@ -448,6 +448,18 @@ if data is not None:
     # Target Properties Configuration
     if target_columns:
         st.subheader("Properties Configuration")
+
+        # Multi-objective strategy selection
+        mobo_strategy = "weighted_sum" # Default
+        if len(target_columns) > 1:
+            mobo_strategy = st.selectbox(
+                "Multi-Objective Strategy:",
+                options=["weighted_sum", "parego"],
+                index=0,
+                format_func=lambda x: "Weighted Sum (Fixed Weights)" if x == "weighted_sum" else "ParEGO (Randomized Weights)",
+                help="Choose how to handle multiple objectives. ParEGO can help explore non-convex Pareto fronts.",
+                key="mobo_strategy_selector"
+            )
         
         max_or_min_targets, weights_targets, thresholds_targets = [], [], []
         max_or_min_apriori, weights_apriori, thresholds_apriori = [], [], []


### PR DESCRIPTION
Partial completion of Phase 3, Step 4 (Refine Multi-Objective Optimization):
- Added a `st.selectbox` in `main.py` to allow users to choose a multi-objective strategy ('Weighted Sum' or 'ParEGO') when multiple target properties are selected.
- The `multi_objective_bayesian_optimization` function in `app/bayesian_optimizer.py` (which was previously made ParEGO-aware) is now ready to receive this strategy, although `main.py` does not yet explicitly call this function in its main experiment loop.

Further work is needed in `main.py` to fully integrate the revamped BayesianOptimizer with flexible surrogates and use this selected MOBO strategy.