### PR TITLE
Fix: Resolve MAML, Reptile, and ProtoNet runtime errors

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -235,9 +235,11 @@ def initialize_scheduler(optimizer, scheduler_type, **kwargs):
         factor = kwargs.get("factor", 0.5)
         patience = kwargs.get("patience", 5)
         threshold = kwargs.get("threshold", 1e-4)
+        min_lr = kwargs.get("min_lr", 0) # Get min_lr from kwargs, default to 0
+        verbose = kwargs.get("verbose", False) # Get verbose from kwargs, default to False
         return optim.lr_scheduler.ReduceLROnPlateau(
-            optimizer, mode='min', factor=factor, patience=patience, 
-            threshold=threshold, verbose=True
+            optimizer, mode='min', factor=factor, patience=patience,
+            threshold=threshold, min_lr=min_lr, verbose=verbose
         )
     
     elif scheduler_type == "StepLR":


### PR DESCRIPTION
This commit addresses several runtime errors identified during testing:

1.  **MAML (`ValueError` in `calculate_utility`):** Corrected `evaluate_maml` in `app/models.py` to properly unpack the tuple returned by `calculate_uncertainty_ensemble`.

2.  **Reptile (`AttributeError` on `uncertainty_scores.ndim`):** Corrected `evaluate_reptile` in `app/reptile_model.py` to properly unpack the tuple from `calculate_uncertainty_ensemble`.

3.  **ProtoNet (`TypeError` in scheduler initialization):** Modified `initialize_scheduler` in `app/utils.py` to correctly retrieve and pass `min_lr` and `verbose` arguments from `kwargs` to the `ReduceLROnPlateau` scheduler. This was called by `protonet_train`.

4.  **Previous `ImportError` and `SyntaxError` fixes:** Includes earlier corrections for import statements in `main.py` and indentation/duplicated code in `app/models.py` and `app/protonet_model.py`.