### PR TITLE
Fix: Correct SyntaxError in app/utils.py for scheduler init

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -231,7 +231,6 @@ def initialize_scheduler(optimizer, scheduler_type, **kwargs):
         )
     
     elif scheduler_type == "ReduceLROnPlateau":
-    elif scheduler_type == "ReduceLROnPlateau":
         # Reduce learning rate when a metric stops improving
         # Explicitly define all parameters for clarity and to avoid TypeErrors
         # from unexpected interactions with kwargs if a parameter is missing.


### PR DESCRIPTION
Removed a duplicated `elif` condition in the `initialize_scheduler` function within `app/utils.py`. This syntax error was preventing the module from being imported correctly, leading to errors downstream, likely including the TypeError reported for ProtoNet model initialization.

This commit builds upon previous fixes for MAML and Reptile runtime errors.