### PR TITLE
Fix: Resolve runtime errors for MAML, Reptile, and ProtoNet models

### DIFF
--- a/app/protonet_model.py
+++ b/app/protonet_model.py
@@ -597,7 +597,8 @@ def evaluate_protonet(model, data, input_columns, target_columns, curiosity, wei
     # Calculate uncertainty using Monte Carlo dropout from app.models
     from app.models import calculate_uncertainty_ensemble
     # model.train() is handled by calculate_uncertainty_ensemble
-    uncertainty_scores = calculate_uncertainty_ensemble(
+    # Unpack the tuple correctly: (uncertainty_array, mc_samples_stack)
+    uncertainty_scores, _ = calculate_uncertainty_ensemble(
         model=model,
         X=inputs_infer_tensor,
         num_samples=50, # Corresponds to num_perturbations


### PR DESCRIPTION
This commit addresses several runtime errors:

1.  MAML (`ValueError`): Corrected `evaluate_maml` to properly unpack the tuple from `calculate_uncertainty_ensemble`.

2.  Reptile (`AttributeError`): Corrected `evaluate_reptile` to properly unpack the tuple from `calculate_uncertainty_ensemble`.

3.  ProtoNet (`TypeError` during `protonet_train` call): Removed duplicated function definitions and orphaned code lines in `app/protonet_model.py`. Corrected `initialize_scheduler` in `app/utils.py` for robust `ReduceLROnPlateau` instantiation.

4.  ProtoNet (`AttributeError` in `evaluate_protonet`): Corrected `evaluate_protonet` to properly unpack the tuple from `calculate_uncertainty_ensemble`.

Includes previous related fixes for imports and syntax. All models should now run without these specific errors.